### PR TITLE
installs the ca-certificates package on Debian Wheezy.

### DIFF
--- a/debian/wheezy/Dockerfile
+++ b/debian/wheezy/Dockerfile
@@ -3,7 +3,8 @@ FROM debian:wheezy
 LABEL maintainer me@danvaida.com
 
 RUN apt-get -y update
-RUN apt-get -y install python-pip=1.1-3 \
+RUN apt-get -y install ca-certificates=20130119+deb7u1 \
+                       python-pip=1.1-3 \
                        python-dev=2.7.3-4+deb7u1 \
                        libffi-dev=3.0.10-3
 

--- a/debian/wheezy/Dockerfile
+++ b/debian/wheezy/Dockerfile
@@ -3,7 +3,7 @@ FROM debian:wheezy
 LABEL maintainer me@danvaida.com
 
 RUN apt-get -y update
-RUN apt-get -y install ca-certificates=20130119+deb7u1 \
+RUN apt-get -y install ca-certificates \
                        python-pip=1.1-3 \
                        python-dev=2.7.3-4+deb7u1 \
                        libffi-dev=3.0.10-3


### PR DESCRIPTION
Some requests against various HTTP**s** endpoints are failing due to the lack of CA certs in the container.