### PR TITLE
Reducing debian images sizes

### DIFF
--- a/debian/stretch/Dockerfile
+++ b/debian/stretch/Dockerfile
@@ -5,10 +5,10 @@ LABEL maintainer me@danvaida.com
 RUN DEBIAN_FRONTEND=noninteractive \
     apt-get update -y \
     && apt-get install --no-install-recommends -y \
-        apt-transport-https=1.4.4 \
+        apt-transport-https=1.4.6 \
         ca-certificates \
         gnupg=2.1.18-6 \
-        libssl-dev=1.1.0e-2 \
+        libssl-dev=1.1.0f-3 \
         python-dev=2.7.13-2 \
         python-setuptools=33.1.1-1 \
         python-wheel=0.29.0-2 \

--- a/debian/stretch/Dockerfile
+++ b/debian/stretch/Dockerfile
@@ -2,10 +2,21 @@ FROM debian:stretch
 
 LABEL maintainer me@danvaida.com
 
-RUN apt-get update
-RUN apt-get install -y apt-transport-https \
-                       ca-certificates \
-                       gnupg \
-                       python-pip
-
-RUN pip install ansible==2.2
+RUN DEBIAN_FRONTEND=noninteractive \
+    apt-get update -y \
+    && apt-get install --no-install-recommends -y \
+        apt-transport-https=1.4.4 \
+        ca-certificates \
+        gnupg=2.1.18-6 \
+        libssl-dev=1.1.0e-2 \
+        python-dev=2.7.13-2 \
+        python-setuptools=33.1.1-1 \
+        python-wheel=0.29.0-2 \
+        python-pip=9.0.1-2 \
+        build-essential=12.3 \
+    && pip install --upgrade pip cffi \
+    && pip install ansible==2.2 \
+    && apt-get remove -f -y --purge --auto-remove build-essential \
+    && apt-get clean \
+    && apt-get autoremove -y \
+    && rm -rf /var/lib/apt/lists/* /tmp/* /root/.cache

--- a/debian/wheezy/Dockerfile
+++ b/debian/wheezy/Dockerfile
@@ -2,16 +2,22 @@ FROM debian:wheezy
 
 LABEL maintainer me@danvaida.com
 
-RUN echo "deb http://ftp.debian.org/debian wheezy-backports main" >> /etc/apt/sources.list \
-    && apt-get -y update \
-    && apt-get -y install apt-transport-https=0.9.7.9+deb7u7 \
-                          ca-certificates \
-                          python-dev=2.7.3-4+deb7u1 \
-                          python-ndg-httpsclient=0.3.2-1~bpo70+1 \
-                          python-openssl=0.13-2+deb7u1 \
-                          python-pip=1.1-3 \
-                          python-pyasn1=0.1.3-1 \
-                          python-urllib3=1.3-3 \
-                          libffi-dev=3.0.10-3 \
+RUN DEBIAN_FRONTEND=noninteractive \
+    BACKPORTS='deb http://ftp.debian.org/debian wheezy-backports main' \
+    && echo "$BACKPORTS" >> /etc/apt/sources.list \
+    && apt-get update -y \
+    && apt-get install -y \
+        apt-transport-https=0.9.7.9+deb7u7 \
+        ca-certificates \
+        python-dev=2.7.3-4+deb7u1 \
+        python-ndg-httpsclient=0.3.2-1~bpo70+1 \
+        python-openssl=0.13-2+deb7u1 \
+        python-pip=1.1-3 \
+        python-pyasn1=0.1.3-1 \
+        python-urllib3=1.3-3 \
+        libffi-dev=3.0.10-3 \
     && pip install ansible==2.2 \
-    && apt-get autoremove -y
+    && apt-get remove -f -y --purge --auto-remove build-essential \
+    && apt-get clean \
+    && apt-get autoremove -y \
+    && rm -rf /var/lib/apt/lists/* /tmp/*


### PR DESCRIPTION
The image for Debian Stretch wasn't following the same pattern used for the other images in this repository, resulting in a large and not optimized image. This pull request introduces package pinning like the other images and more aggressive cleanup. Here is the comparison:

    $ docker images | grep ansible-roles-test-stretch
    ansible-roles-test-stretch-clean        latest              25c4aa8e86a8        12 minutes ago      282 MB
    ansible-roles-test-stretch              latest              35e27bf95bea        3 hours ago         543 MB

I also took the chance to do some small improvements on the Debian Wheezy image. I would like to introduce the `--no-install-recommends` for that image, but this unfortunately breaks the build.