### PR TITLE
Coding standards: uniformizes the indentation in the repository

### DIFF
--- a/amazon/2016.09/Dockerfile
+++ b/amazon/2016.09/Dockerfile
@@ -3,13 +3,14 @@ FROM amazonlinux:2016.09
 LABEL maintainer me@danvaida.com
 
 RUN yum update -y \
- && yum install -y ca-certificates \
-                   gcc-4.8.3-3.20.amzn1 \
-                   openssl-1.0.1k-15.96.amzn1 \
-                   openssl-devel-1.0.1k-15.99.amzn1.x86_64 \
-                   python27-devel-2.7.12-2.120.amzn1 \
-                   python27-pip-6.1.1-1.23.amzn1 \
- && pip install --upgrade pip setuptools \
- && pip install ansible==2.2 \
- && yum clean -y all \
- && yum remove -y gcc
+    && yum install -y \
+        ca-certificates \
+        gcc-4.8.3-3.20.amzn1 \
+        openssl-1.0.1k-15.96.amzn1 \
+        openssl-devel-1.0.1k-15.99.amzn1.x86_64 \
+        python27-devel-2.7.12-2.120.amzn1 \
+        python27-pip-6.1.1-1.23.amzn1 \
+    && pip install --upgrade pip setuptools \
+    && pip install ansible==2.2 \
+    && yum clean -y all \
+    && yum remove -y gcc

--- a/centos/7/Dockerfile
+++ b/centos/7/Dockerfile
@@ -3,9 +3,9 @@ FROM centos:7
 LABEL maintainer me@danvaida.com
 
 RUN (cd /lib/systemd/system/sysinit.target.wants/; \
-      for i in *; do \
-        [ $i == systemd-tmpfiles-setup.service ] || rm -f $i; \
-      done); \
+        for i in *; do \
+            [ $i == systemd-tmpfiles-setup.service ] || rm -f $i; \
+        done); \
     rm -f /lib/systemd/system/multi-user.target.wants/*; \
     rm -f /etc/systemd/system/*.wants/*; \
     rm -f /lib/systemd/system/local-fs.target.wants/*; \
@@ -16,13 +16,14 @@ RUN (cd /lib/systemd/system/sysinit.target.wants/; \
 
 RUN yum update -y \
     && yum install -y epel-release \
-    && yum install -y ca-certificates \
-                   gcc-4.8.5-11.el7 \
-                   openssl-1.0.1e-60.el7_3.1 \
-                   openssl-devel-1.0.1e-60.el7_3.1 \
-                   python2-pip-8.1.2-5.el7 \
-                   python-devel-2.7.5-48.el7 \
-                   libffi-devel-3.0.13-18.el7 \
+    && yum install -y \
+        ca-certificates \
+        gcc-4.8.5-11.el7 \
+        openssl-1.0.1e-60.el7_3.1 \
+        openssl-devel-1.0.1e-60.el7_3.1 \
+        python2-pip-8.1.2-5.el7 \
+        python-devel-2.7.5-48.el7 \
+        libffi-devel-3.0.13-18.el7 \
     && pip install --upgrade setuptools pip \
     && pip install ansible==2.2 \
     && yum clean -y all \

--- a/debian/jessie/Dockerfile
+++ b/debian/jessie/Dockerfile
@@ -5,17 +5,17 @@ LABEL maintainer me@danvaida.com
 RUN DEBIAN_FRONTEND=noninteractive \
     apt-get update -y \
     && apt-get install --fix-missing \
-    && apt-get install -y apt-transport-https=1.0.9.8.4 \
-           gcc='4:4.9.2-2' \
-           libffi-dev='3.1-2+b2' \
-           libssl-dev='1.0.1t-1+deb8u6' \
-           python=2.7.9-1 \
-           python-dev=2.7.9-1 \
-           python-pip=1.5.6-5 \
-           python-yaml=3.11-2 \
+    && apt-get install -y \
+        apt-transport-https=1.0.9.8.4 \
+        gcc='4:4.9.2-2' \
+        libffi-dev='3.1-2+b2' \
+        libssl-dev='1.0.1t-1+deb8u6' \
+        python=2.7.9-1 \
+        python-dev=2.7.9-1 \
+        python-pip=1.5.6-5 \
+        python-yaml=3.11-2 \
     && pip install --upgrade cffi pip \
     && pip install ansible==2.2 \
-    && apt-get remove -f -y --purge --auto-remove \
-           gcc \
+    && apt-get remove -f -y --purge --auto-remove gcc \
     && apt-get clean \
-    && rm -rf /var/lib/apt/lists/*  /tmp/*
+    && rm -rf /var/lib/apt/lists/* /tmp/*

--- a/debian/wheezy/aws.Dockerfile
+++ b/debian/wheezy/aws.Dockerfile
@@ -2,6 +2,7 @@ FROM danvaida/ansible-docker-images:debian-wheezy
 
 LABEL maintainer me@danvaida.com
 
-RUN pip install boto==2.42.0 \
-                boto3==1.4.4 \
-                botocore==1.5.1
+RUN pip install \
+        boto==2.42.0 \
+        boto3==1.4.4 \
+        botocore==1.5.1

--- a/oracle/7/Dockerfile
+++ b/oracle/7/Dockerfile
@@ -7,13 +7,14 @@ RUN yum update -y \
     && wget https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm \
     && rpm -ivh epel-release-latest-7.noarch.rpm \
     && yum update -y \
-    && yum install -y ca-certificates \
-                      gcc-4.8.5-11.el7 \
-                      openssl-1.0.1e-60.el7_3.1 \
-                      openssl-devel-1.0.1e-60.el7_3.1 \
-                      python2-pip-8.1.2-5.el7 \
-                      python-devel-2.7.5-48.0.1.el7 \
-                      libffi-devel-3.0.13-18.el7 \
+    && yum install -y \
+        ca-certificates \
+        gcc-4.8.5-11.el7 \
+        openssl-1.0.1e-60.el7_3.1 \
+        openssl-devel-1.0.1e-60.el7_3.1 \
+        python2-pip-8.1.2-5.el7 \
+        python-devel-2.7.5-48.0.1.el7 \
+        libffi-devel-3.0.13-18.el7 \
     && pip install --upgrade setuptools pip \
     && pip install ansible==2.2 \
     && rm epel-release-latest-7.noarch.rpm \


### PR DESCRIPTION
This pull request is a suggestion to uniformize the indentation used in this repository. Once the expand tab size used here is essentially 4 spaces, no indentation should exist which is not a multiple of 4 spaces.

Also, arbitrary indentation for pure alignment purposes should be avoided. With time it makes difficult to follow what was changed in each commit, specially when the length of the indentation is changed to match the alignment of other elements.

The Dockerfiles for Debian Wheezy and Debian Stretch were not affect by this pull request because another open pull request #11 (approval pending) already adheres to the standards suggested here.