### PR TITLE
pins down the paramiko pip package to fix the building of amazonlinux.

### DIFF
--- a/amazon/2016.09/Dockerfile
+++ b/amazon/2016.09/Dockerfile
@@ -11,6 +11,6 @@ RUN yum update -y \
         python27-devel-2.7.12-2.120.amzn1 \
         python27-pip-6.1.1-1.23.amzn1 \
     && pip install --upgrade pip setuptools \
-    && pip install ansible==2.2 \
+    && pip install paramiko==2.1.2 ansible==2.2 \
     && yum clean -y all \
     && yum remove -y gcc


### PR DESCRIPTION
This fixes issue #13 
Successful build job is here: https://hub.docker.com/r/danvaida/ansible-docker-images/builds/bdbzyzcrky58aqrekrzqswc/