### PR TITLE
Adds AWS-ready image based on Debian Stretch slim.

### DIFF
--- a/debian/stretch/aws-slim.Dockerfile
+++ b/debian/stretch/aws-slim.Dockerfile
@@ -1,0 +1,8 @@
+FROM danvaida/ansible-docker-images:debian-stretch-slim
+
+LABEL maintainer me@danvaida.com
+
+RUN pip install \
+        boto==2.42.0 \
+        boto3==1.4.4 \
+        botocore==1.5.1


### PR DESCRIPTION
Successful build here: https://hub.docker.com/r/danvaida/ansible-docker-images/builds/bzarry4qjyrjama7zufunc9/